### PR TITLE
[cleanup] rerouted all server calls to /api/ to separate from client …

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -199,10 +199,9 @@ Handle setup of app, load in Angular dependencies, routing, etc.
       }
     });
 
-    // $locationProvider.html5Mode({
-    //   enabled: true,
-    //   requireBase: false
-    // });
+
+    // enable html5 mode to eliminate hashbang
+    // $locationProvider.html5Mode(true);
 
   }
 

--- a/client/app/components/home/home.jade
+++ b/client/app/components/home/home.jade
@@ -26,9 +26,9 @@
 .content.align-top  
   .large-child.post-list(infinite-scroll="addMorePosts(posts[posts.length-1])" infinite-scroll-disabled="busy" infinite-scroll-distance="0" infinite-scroll-immediate-check="false")
     ul.category-list
-        a.recent-posts-btn(href="#" ng-click="updateCategory('top')", ng-class="{underscore: category==='top'}")
+        a.recent-posts-btn(href="/#/#" ng-click="updateCategory('top')", ng-class="{underscore: category==='top'}")
             li Top Posts
-        a.top-posts-btn(href="#" ng-click="updateCategory('recent')", ng-class="{underscore: category==='recent'}")
+        a.top-posts-btn(href="/#/#" ng-click="updateCategory('recent')", ng-class="{underscore: category==='recent'}")
             li Recent Posts
     .post-item(ng-repeat="post in posts")
       .post-date

--- a/client/app/components/home/homeController.js
+++ b/client/app/components/home/homeController.js
@@ -8,7 +8,7 @@
     //for new post link
     $scope.user = userFactory.getUserInfo();
     if ($scope.user) {
-      $scope.newPostUrl = "/post/add?username=" + $scope.user.username + "&token=" + $scope.user.token;
+      $scope.newPostUrl = "api/post/add?username=" + $scope.user.username + "&token=" + $scope.user.token;
     }
 
     //sort categories

--- a/client/app/components/post/postFactory.js
+++ b/client/app/components/post/postFactory.js
@@ -13,7 +13,7 @@
       getTopPosts: function() {
         return $http({
           method: 'GET',
-          url: '/post/top'
+          url: 'api/post/top'
         }).then(function(resp) {
           return resp.data;
         });
@@ -23,7 +23,7 @@
       getRecentPosts: function() {
         return $http({
           method: 'GET',
-          url: '/post/recent'
+          url: 'api/post/recent'
         }).then(function(resp) {
           return resp.data;
         });
@@ -37,7 +37,7 @@
         if (lastLike !== 'undefined' && lastLike !== null) {
           return $http({
             method: 'GET',
-            url: 'post/more/top',
+            url: 'api/post/more/top',
             params: {
               last_post_id: lastPostId,
               last_like: lastLike
@@ -46,7 +46,7 @@
         } else {
           return $http({
             method: 'GET',
-            url: 'post/more/recent',
+            url: 'api/post/more/recent',
             params: {
               last_post_id: lastPostId
             }
@@ -58,7 +58,7 @@
       getPostData: function(id) {
         return $http({
           method: 'GET',
-          url: '/post/info',
+          url: 'api/post/info',
           params: {
             post_id: id
           }
@@ -105,7 +105,7 @@
       toggleLike: function(userId, postId) {
         return $http({
           method: 'GET',
-          url: '/like/toggle',
+          url: 'api/like/toggle',
           params: {
             user_id: userId,
             post_id: postId
@@ -119,7 +119,7 @@
       getLikeStatus: function(userId, postId) {
         return $http({
           method: 'GET',
-          url: '/like/status',
+          url: 'api/like/status',
           params: {
             user_id: userId,
             post_id: postId
@@ -135,7 +135,7 @@
         $.get("http://ipinfo.io", function (response) {
             return $http({
               method: 'POST',
-              url: '/view/add',
+              url: 'api/view/add',
               data: {
                 post_id: postId,
                 user_id: userId,
@@ -143,13 +143,13 @@
               }
             });
         }, "jsonp");
-        
+
       },
 
       addComment: function(post_id, paragraph, user_id, text) {
         return $http({
           method: 'POST',
-          url: '/comment/add',
+          url: 'api/comment/add',
           data: {
             post_id: post_id,
             paragraph: paragraph,
@@ -162,7 +162,7 @@
       deleteComment: function(comment_id) {
         return $http({
           method: 'DELETE',
-          url: '/comment/delete',
+          url: 'api/comment/delete',
           params: {
             comment_id: comment_id
           }

--- a/client/app/components/search/searchFactory.js
+++ b/client/app/components/search/searchFactory.js
@@ -7,7 +7,7 @@
         searchPostsByTag: function(tag) {
           return $http({
             method: 'GET',
-            url: '/search/tag',
+            url: 'api/search/tag',
             params: {
               tag: tag
             }

--- a/client/app/components/signup/signup.jade
+++ b/client/app/components/signup/signup.jade
@@ -5,7 +5,7 @@
       p The fast and easy way to share your technical writing
     .signup-content
       .signup-steps
-        a.btn-auth.btn-github.large(href="/auth/github") Sign in with Github
+        a.btn-auth.btn-github.large(href="api/auth/github") Sign in with Github
         ul
           li.one Sign up with your Github account
           li.two Push markdown into your &lt;code&gt;snap repo

--- a/client/app/components/tag/tagFactory.js
+++ b/client/app/components/tag/tagFactory.js
@@ -8,7 +8,7 @@
       getTags: function() {
         return $http({
         method: 'GET',
-        url: '/tags'
+        url: 'api/tags'
         }).then(function(resp) {
           return resp.data;
         });
@@ -16,7 +16,7 @@
       getPopularTags: function() {
         return $http({
           method: 'GET',
-          url: '/tags/popular'
+          url: 'api/tags/popular'
         }).then(function(resp) {
           return resp.data;
         });
@@ -25,7 +25,7 @@
       getUserTags: function(username){
         return $http({
           method: 'GET',
-          url: '/tags/user',
+          url: 'api/tags/user',
           params: {
             username: username
           }
@@ -42,7 +42,7 @@
       getTagPattern: function(tagName) {
         return $http({
           method: 'GET',
-          url: '/tags/pattern',
+          url: 'api/tags/pattern',
           params: {
             tagName: tagName
           }

--- a/client/app/shared/auth/authFactory.js
+++ b/client/app/shared/auth/authFactory.js
@@ -6,7 +6,7 @@
       checkAuth: function(callback) {
         return $http({
           method: 'GET',
-          url: 'auth/checkauth'
+          url: 'api/auth/checkauth'
         });
       },
       /* Returns true or false depending on whether the current user is logged in. */
@@ -23,7 +23,7 @@
       logout: function() {
         $http({
           method: 'GET',
-          url: 'auth/logout'
+          url: 'api/auth/logout'
         }).then(function(res) {
           delete window.localStorage.codeSnapJwtToken;
           $state.go('signup');

--- a/client/app/shared/navbar/navbarDirective.js
+++ b/client/app/shared/navbar/navbarDirective.js
@@ -44,7 +44,7 @@
                 userFactory.setUserInfo(user);
                 $rootScope.user = user;
                 $scope.loggedIn = !!user;
-                $scope.newPostUrl = "/post/add?username=" + user.username + "&token=" + user.token;
+                $scope.newPostUrl = "api/post/add?username=" + user.username + "&token=" + user.token;
               });
           }
         });

--- a/client/app/shared/navbar/searchbarDirective.js
+++ b/client/app/shared/navbar/searchbarDirective.js
@@ -9,7 +9,7 @@
           $('.ui.search')
             .search({
               apiSettings: {
-                url: 'search/?q={query}'
+                url: 'api/search/?q={query}'
               },
               type: 'category',
               searchDelay: 100,

--- a/client/app/shared/subnavs/profileSubnav.jade
+++ b/client/app/shared/subnavs/profileSubnav.jade
@@ -3,9 +3,9 @@ section.subnav.sticky(profile-subnav)
         .small-child
         .large-child
             ul.category-list
-                a( href="#" ng-click="updateProfilePosts('recent')", ng-class="{underscore: category==='recent'}")
+                a( href="#/#" ng-click="updateProfilePosts('recent')", ng-class="{underscore: category==='recent'}")
                     li Recent Posts
-                a(href="#" ng-click="updateProfilePosts('top')", ng-class="{underscore: category==='top'}")
+                a(href="#/#" ng-click="updateProfilePosts('top')", ng-class="{underscore: category==='top'}")
                     li Top Posts
-                a(href="#" ng-click="updateProfilePosts('unpublished')", ng-class="{underscore: category==='unpublished'}" ng-show="isCurrentUser")
+                a(href="#/#" ng-click="updateProfilePosts('unpublished')", ng-class="{underscore: category==='unpublished'}" ng-show="isCurrentUser")
                     li Unpublished

--- a/client/app/shared/user/userFactory.js
+++ b/client/app/shared/user/userFactory.js
@@ -11,7 +11,7 @@
       getUser: function() {
         return $http({
           method: 'GET',
-          url: '/user/info/',
+          url: 'api/user/info/',
           params: {
             user_id: window.localStorage.codeSnapJwtToken
           }
@@ -21,7 +21,7 @@
       getUserByUsername: function(username) {
         return $http({
           method: 'GET',
-          url: '/user/profile/',
+          url: 'api/user/profile/',
           params: {
             username: username
           }
@@ -34,7 +34,7 @@
       removeUser: function() {
         return $http({
           method: 'DELETE',
-          url: '/user/info/',
+          url: 'api/user/info/',
           params: {
             user_id: localStorage.codeSnapJwtToken
           }
@@ -45,7 +45,7 @@
       ownsProfile: function(jwtToken, username) {
         return $http({
           method: 'GET',
-          url: '/user/profile/owner',
+          url: 'api/user/profile/owner',
           params: {
             username: username,
             user_id: localStorage.codeSnapJwtToken
@@ -58,7 +58,7 @@
       getTopUserPosts: function(username) {
         return $http({
           method: 'GET',
-          url: '/post/user/top',
+          url: 'api/post/user/top',
           params: {
             username: username
           }
@@ -70,7 +70,7 @@
       getRecentUserPosts: function(username) {
         return $http({
           method: 'GET',
-          url: '/post/user/recent',
+          url: 'api/post/user/recent',
           params: {
             username: username
           }
@@ -82,7 +82,7 @@
       newUser: function(username) {
         return $http({
           method: 'GET',
-          url: '/user/new',
+          url: 'api/user/new',
           params: {
             username: username
           }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var gulp = require('gulp'),
   del = require('del'),
   imagemin = require('gulp-imagemin'),
   webdriver_standalone = require("gulp-protractor").webdriver_standalone,
+  autoprefixer = require('gulp-autoprefixer'),
   protractor = require("gulp-protractor").protractor;
 
 /* asset paths */
@@ -95,6 +96,10 @@ gulp.task('sass', function () {
   return gulp.src(paths.css)
     .pipe(sourcemaps.init())
     .pipe(sass())
+    .pipe(autoprefixer({
+      browsers: ['last 2 versions'],
+      cascade: false
+    }))
     .pipe(minifyCss())
     .pipe(concatCss("styles.min.css"))
     .pipe(sourcemaps.write())

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "front-matter": "^1.0.0",
     "fuzzyset.js": "0.0.1",
     "gulp": "^3.9.0",
+    "gulp-autoprefixer": "^2.3.1",
     "gulp-concat": "^2.6.0",
     "gulp-eslint": "^0.15.0",
     "gulp-imagemin": "^2.3.0",

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -23,10 +23,24 @@
     app.use(bodyParser.json());
 
     /* Tell express where to look for static files.  The file listed becomes the root directory for static files. */
-    app.use(express.static(process.env.CLIENT_FILES));
+    app.use('/', express.static(process.env.CLIENT_FILES));
+    // app.all(['/', '/profile/*', '/tag/*', '/post/*', '/signup', '/faq', '/account'], function(req, res, next) {
+    //   // Just send the index.html for other files to support HTML5Mode
+    //   res.sendFile('index.html', { root: __dirname + "../../../" + process.env.CLIENT_FILES });
+    // });
+
+
 
     /* Initialize passport for authentication */
     app.use(passport.initialize());
+
+
+    // routing for html5 mode
+    // app.all('/*', function(req, res, next) {
+    //   // Just send the index.html for other files to support HTML5Mode
+    //   res.sendFile('index.html', { root: __dirname });
+    // });
+
 
     /* Required Routes */
     require('../routes/posts.server.routes')(app);

--- a/server/controllers/search.server.controller.js
+++ b/server/controllers/search.server.controller.js
@@ -21,7 +21,7 @@
         var tagObj = tagResults.map(function(tag) {
           return {
             title: tag.title,
-            url: "#/tag/" + tag.title
+            url: "/tag/" + tag.title
           };
         });
         response.results.tags = {
@@ -37,7 +37,7 @@
               var authorObj = authorResults.map(function(author) {
                 return {
                   title: author.name,
-                  url: "#/profile/" + author.username,
+                  url: "/profile/" + author.username,
                   image: author.profile_photo_url,
                   description: author.username
                 };
@@ -55,7 +55,7 @@
                 var titleObj = titleResults.map(function(post) {
                   return {
                     title: post.post_title,
-                    url: "#/post/" + post.post_id,
+                    url: "/post/" + post.post_id,
                     description: post.author
                   };
                 });

--- a/server/controllers/users.server.controller.js
+++ b/server/controllers/users.server.controller.js
@@ -13,7 +13,7 @@
           /* If user is logging in for the first time, redirect them to their profile page.
                We determine if user is logging in for the first time by checking to see if account was created in the past 2 minutes */
           if((new Date() - createdAt) / (1000 * 60) < 2 ) {
-            res.redirect('/#/profile/' + user.get('username'));
+            res.redirect('/profile/' + user.get('username'));
           } else {
             /* If user is returning, redirect to the home page */
             res.redirect('/');

--- a/server/routes/comments.server.routes.js
+++ b/server/routes/comments.server.routes.js
@@ -5,10 +5,10 @@
   module.exports = function(app) {
 
     /* Adds comment to database */
-    app.post('/comment/add', comments.addComment);
+    app.post('/api/comment/add', comments.addComment);
 
     /* Remove comment from database */
-    app.delete('/comment/delete', comments.deleteComment);
+    app.delete('/api/comment/delete', comments.deleteComment);
   };
 
 })();

--- a/server/routes/githubWebhooks.server.routes.js
+++ b/server/routes/githubWebhooks.server.routes.js
@@ -4,7 +4,7 @@
 
   module.exports = function(app) {
     /* Receives Github webhooks containing information on which posts have been added, edited and deleted. */
-    app.post('/api/postreceive/github', postCtrl.postReceive);
+    app.post('/postreceive/github', postCtrl.postReceive);
   };
 
 })();

--- a/server/routes/githubWebhooks.server.routes.js
+++ b/server/routes/githubWebhooks.server.routes.js
@@ -4,7 +4,7 @@
 
   module.exports = function(app) {
     /* Receives Github webhooks containing information on which posts have been added, edited and deleted. */
-    app.post('/postreceive/github', postCtrl.postReceive);
+    app.post('/api/postreceive/github', postCtrl.postReceive);
   };
 
 })();

--- a/server/routes/likes.server.routes.js
+++ b/server/routes/likes.server.routes.js
@@ -6,9 +6,9 @@
   module.exports = function(app) {
 
     /* Respons with all tags from database */
-    app.get('/like/toggle', likes.toggleLike);
+    app.get('/api/like/toggle', likes.toggleLike);
 
-    app.get('/like/status', likes.checkLike);
+    app.get('/api/like/status', likes.checkLike);
 
   };
 

--- a/server/routes/posts.server.routes.js
+++ b/server/routes/posts.server.routes.js
@@ -5,27 +5,27 @@
   module.exports = function(app) {
     /* Paramenters: post_id
        Data returned: post_id, post_title, post_url, post_author */
-    app.get('/post/info', posts.postInfo);
+    app.get('/api/post/info', posts.postInfo);
 
-    app.get('/post/top', posts.topPosts);
+    app.get('/api/post/top', posts.topPosts);
 
-    app.get('/post/recent', posts.recentPosts);
+    app.get('/api/post/recent', posts.recentPosts);
 
-    app.get('/post/addview', posts.addView);
+    app.get('/api/post/addview', posts.addView);
 
-    app.get('/post/add', posts.addPost);
+    app.get('/api/post/add', posts.addPost);
 
     //parameters: a specific post
     //data returned: 20 posts after
-    app.get('/post/more/recent', posts.getMoreRecentPosts);
-    app.get('/post/more/top', posts.getMoreTopPosts);
+    app.get('/api/post/more/recent', posts.getMoreRecentPosts);
+    app.get('/api/post/more/top', posts.getMoreTopPosts);
     /* Parameters: username
        Returns 20 most recent posts */
-    app.get('/post/user/recent', posts.recentUserPosts);
+    app.get('/api/post/user/recent', posts.recentUserPosts);
 
     /* Parameters: username
        Returns 20 most popular posts */
-    app.get('/post/user/top', posts.topUserPosts);
+    app.get('/api/post/user/top', posts.topUserPosts);
   };
 
 })();

--- a/server/routes/search.server.routes.js
+++ b/server/routes/search.server.routes.js
@@ -5,9 +5,9 @@
   module.exports = function(app) {
 
     /* autocomplete results */
-    app.get('/search', search.findAutocompletePosts);
+    app.get('/api/search', search.findAutocompletePosts);
     /*search results for tags, authors, and all */
-    app.get('/search/tag', search.findPostsByTag);
+    app.get('/api/search/tag', search.findPostsByTag);
   };
 
 })();

--- a/server/routes/tags.server.routes.js
+++ b/server/routes/tags.server.routes.js
@@ -6,15 +6,15 @@
   module.exports = function(app) {
 
     /* Responds with all tags from database */
-    app.get('/tags', tags.getTags);
+    app.get('/api/tags', tags.getTags);
 
     /* Responds with top tags from database */
-    app.get('/tags/popular', tags.getPopularTags);
+    app.get('/api/tags/popular', tags.getPopularTags);
 
     /* Responds a list of tags assigned to a users published post */
-    app.get('/tags/user', tags.getUserTags);
+    app.get('/api/tags/user', tags.getUserTags);
 
-    app.get('/tags/pattern', tags.getTagPattern);
+    app.get('/api/tags/pattern', tags.getTagPattern);
   };
 
 

--- a/server/routes/users.server.routes.js
+++ b/server/routes/users.server.routes.js
@@ -14,7 +14,7 @@
       the user to github.com.  After authorization, GitHubwill redirect the user
       back to this application at /auth/github/callback */
 
-    app.get('/auth/github',
+    app.get('/api/auth/github',
       passport.authenticate('github', { scope: [ 'user', 'public_repo' ] }));
 
 
@@ -23,28 +23,28 @@
       request.  If authentication fails, the user will be redirected back to the
       login page.  Otherwise, the primary route function function will be called,
       which, in this example, will redirect the user to the home page. */
-    app.get('/auth/github/callback',
-      passport.authenticate('github', { failureRedirect: '/#/signup' }), users.githubRedirect);
+    app.get('/api/auth/github/callback',
+      passport.authenticate('github', { failureRedirect: '/signup' }), users.githubRedirect);
 
     /* Passes encoded user id token to client if a session exists.  HTTP request is made to this url in the home page resolve if there is no jwtToken saved in localStorage.  This is a workaround for the difficulty we had passing authentication information to the client from the auth/github/callback */
-    app.get('/auth/checkauth', users.checkAuth);
+    app.get('/api/auth/checkauth', users.checkAuth);
 
     /* Removes session data from server and passes back true if this is done successfully */
-    app.get('/auth/logout', users.logout);
+    app.get('/api/auth/logout', users.logout);
 
     /* Parameters: user_id
        Data returned: all user info [WILL BE UPDATED] */
-    app.get('/user/info', users.userInfo);
+    app.get('/api/user/info', users.userInfo);
 
-    app.get('/user/profile', users.userInfoByUsername);
+    app.get('/api/user/profile', users.userInfoByUsername);
 
     /* Parameters: user_id (jwtToken), username
       Data returned: boolean matching username to the user found with jwtToken */
-    app.get('/user/profile/owner', users.userProfileOwner);
+    app.get('/api/user/profile/owner', users.userProfileOwner);
 
     /* Parameters: user_id
       deletes user from DB */
-    app.delete('/user/info', users.deleteUser);
+    app.delete('/api/user/info', users.deleteUser);
 
 
 };

--- a/server/routes/views.server.routes.js
+++ b/server/routes/views.server.routes.js
@@ -7,7 +7,7 @@
 
     /* Parameters: post_id, address
        Data returned: true or false depending on whether new view was added */
-    app.post('/view/add', views.addView);
+    app.post('/api/view/add', views.addView);
   };
 
 


### PR DESCRIPTION
…paths

The intention is to eventually use html5mode on client side in order to lose the hash. This, unfortunately, may produce unforseen conflicts between server and client paths.

NOTE////// 
If this is merged:

staging and production apps callback urls need to be modified thru codesnaps group settings;
development, production, and staging variables for callback urls and postrecieve must be changed;
all current users of app will need to manually fix their github /postreceive hooks

Given that the last change is pretty undesirable, we could keep /postreceive/github as the hook receiever, but still prepend '/api' to other paths
